### PR TITLE
Add asset class to lamington to allow for currency calculations

### DIFF
--- a/src/contracts/asset.test.ts
+++ b/src/contracts/asset.test.ts
@@ -1,0 +1,97 @@
+const chai = require('chai');
+import { Asset } from './asset';
+
+describe('Asset', function () {
+	context('constructor', function () {
+		it('should work with string input', function () {
+			const a = new Asset('10.12345 TLM');
+			chai.expect(a.amount).to.equal(10.12345);
+			chai.expect(a.symbol).to.equal('TLM');
+			chai.expect(a.precision).to.equal(5);
+			chai.expect(a.toString()).to.equal('10.12345 TLM');
+			chai.expect(a.amount_raw()).to.equal(10.12345 * 10 ** 5);
+		});
+		it('should work with number and symbol input', function () {
+			const a = new Asset(10.1235, 'XYZ');
+			chai.expect(a.amount).to.equal(10.1235);
+			chai.expect(a.symbol).to.equal('XYZ');
+			chai.expect(a.precision).to.equal(4);
+			chai.expect(a.toString()).to.equal('10.1235 XYZ');
+			chai.expect(a.amount_raw()).to.equal(10.1235 * 10 ** 4);
+		});
+		it('should work with number and symbol and precision input', function () {
+			const a = new Asset(10.1235, 'XYZ', 5);
+			chai.expect(a.amount).to.equal(10.1235);
+			chai.expect(a.symbol).to.equal('XYZ');
+			chai.expect(a.precision).to.equal(5);
+			chai.expect(a.toString()).to.equal('10.12350 XYZ');
+			chai.expect(a.amount_raw()).to.equal(10.1235 * 10 ** 5);
+		});
+		it('should fail with incorrect precision', function () {
+			chai
+				.expect(() => {
+					new Asset(10.12356, 'XYZ', 4);
+				})
+				.to.throw('Precision 4 too low to represent 10.12356');
+		});
+	});
+
+	context('addition', function () {
+		it('should work', function () {
+			const a = new Asset(10.1235, 'XYZ');
+			const b = a.add(new Asset(1, 'XYZ'));
+			chai.expect(b.toString()).to.equal('11.1235 XYZ');
+			chai.expect(a.toString()).to.equal('10.1235 XYZ');
+		});
+		it('should not mutate asset', function () {
+			const a = new Asset(10.1235, 'XYZ');
+			const b = a.add(new Asset(1, 'XYZ'));
+			chai.expect(a.toString()).to.equal('10.1235 XYZ');
+		});
+		it('of wrong symbol should fail', function () {
+			const a = new Asset(10.1235, 'XYZ');
+			chai
+				.expect(() => {
+					a.add(new Asset(1, 'ABC'));
+				})
+				.to.throw('Differing symbol');
+		});
+		it('of wrong precision should fail', function () {
+			const a = new Asset(10.1235, 'XYZ', 6);
+			chai
+				.expect(() => {
+					a.add(new Asset(1, 'XYZ'));
+				})
+				.to.throw('Differing precision');
+		});
+	});
+	context('subtraction', function () {
+		it('should work', function () {
+			const a = new Asset(10.1235, 'XYZ');
+			const b = a.sub(new Asset(1, 'XYZ'));
+			chai.expect(b.toString()).to.equal('9.1235 XYZ');
+			chai.expect(a.toString()).to.equal('10.1235 XYZ');
+		});
+		it('should not mutate asset', function () {
+			const a = new Asset(10.1235, 'XYZ');
+			const b = a.sub(new Asset(1, 'XYZ'));
+			chai.expect(a.toString()).to.equal('10.1235 XYZ');
+		});
+		it('of wrong symbol should fail', function () {
+			const a = new Asset(10.1235, 'XYZ');
+			chai
+				.expect(() => {
+					a.sub(new Asset(1, 'ABC'));
+				})
+				.to.throw('Differing symbol');
+		});
+		it('of wrong precision should fail', function () {
+			const a = new Asset(10.1235, 'XYZ', 6);
+			chai
+				.expect(() => {
+					a.sub(new Asset(1, 'XYZ'));
+				})
+				.to.throw('Differing precision');
+		});
+	});
+});

--- a/src/contracts/asset.ts
+++ b/src/contracts/asset.ts
@@ -5,15 +5,15 @@ export class Asset {
 	readonly symbol: string;
 	readonly precision: number;
 
-	constructor(amount: any, symbol?: string, precision = 4) {
+	constructor(amount: string | number, symbol?: string, precision = 4) {
 		if (!symbol) {
-			const [amount_str, symbol_str] = amount.split(' ');
+			const [amount_str, symbol_str] = (amount as string).split(' ');
 			this.amount = parseFloat(amount_str);
 			const decimal_str = amount_str.split('.')[1];
-			this.precision = decimal_str.length;
+			this.precision = precision;
 			this.symbol = symbol_str;
 		} else {
-			this.amount = amount;
+			this.amount = amount as number;
 			this.symbol = symbol;
 			this.precision = precision;
 		}

--- a/src/contracts/asset.ts
+++ b/src/contracts/asset.ts
@@ -10,7 +10,7 @@ export class Asset {
 			const [amount_str, symbol_str] = (amount as string).split(' ');
 			this.amount = parseFloat(amount_str);
 			const decimal_str = amount_str.split('.')[1];
-			this.precision = precision;
+			this.precision = decimal_str.length;
 			this.symbol = symbol_str;
 		} else {
 			this.amount = amount as number;

--- a/src/contracts/asset.ts
+++ b/src/contracts/asset.ts
@@ -1,0 +1,49 @@
+const assert = require('assert');
+
+export class Asset {
+	readonly amount: number;
+	readonly symbol: string;
+	readonly precision: number;
+
+	constructor(amount: any, symbol?: string, precision = 4) {
+		if (!symbol) {
+			const [amount_str, symbol_str] = amount.split(' ');
+			this.amount = parseFloat(amount_str);
+			const decimal_str = amount_str.split('.')[1];
+			this.precision = decimal_str.length;
+			this.symbol = symbol_str;
+		} else {
+			this.amount = amount;
+			this.symbol = symbol;
+			this.precision = precision;
+		}
+
+		const x = Math.round(this.amount * 10 ** this.precision) / 10 ** this.precision;
+		assert(x == this.amount, `Precision ${this.precision} too low to represent ${amount}`);
+	}
+
+	toString() {
+		return `${this.amount.toFixed(this.precision)} ${this.symbol}`;
+	}
+
+	amount_raw() {
+		return this.amount * 10 ** this.precision;
+	}
+
+	assertSame(other: Asset) {
+		assert(this.symbol === other.symbol, `Differing symbol. Trying to add ${other} to ${this}`);
+		assert(
+			this.precision === other.precision,
+			`Differing precision. Trying to add ${other} to ${this}`
+		);
+	}
+
+	add(other: Asset) {
+		this.assertSame(other);
+		return new Asset(this.amount + other.amount, this.symbol, this.precision);
+	}
+	sub(other: Asset) {
+		this.assertSame(other);
+		return new Asset(this.amount - other.amount, this.symbol, this.precision);
+	}
+}

--- a/src/contracts/contract.ts
+++ b/src/contracts/contract.ts
@@ -7,6 +7,7 @@ import { Abi } from 'eosjs/dist/eosjs-rpc-interfaces';
 import { camelCase } from './utils';
 import { ConfigManager, LamingtonDebugLevel } from '../configManager';
 import { Stats } from '../stats';
+import { Asset } from './asset';
 
 export interface ContractActionParameters {
 	[key: string]: any;
@@ -111,7 +112,14 @@ export class Contract implements EOSJSContract {
 				}
 
 				for (let i = 0; i < action.fields.length; i++) {
-					data[action.fields[i].name] = arguments[i];
+					let arg = arguments[i];
+					if (arg instanceof Asset) {
+						arg = String(arg);
+					}
+					if (arg instanceof Account) {
+						arg = arg.name;
+					}
+					data[action.fields[i].name] = arg;
 				}
 
 				// Who are we acting as?

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -4,3 +4,4 @@ export * from './contractLoader';
 export * from './tableRowsResult';
 export * from './typeGenerator';
 export * from './typeMap';
+export * from './asset';


### PR DESCRIPTION
This PR

- Adds an `Asset` class that can be used to represent asset amounts in testing code. It can be given as parameter to `contract.action()` calls instead of `"1.000 TLM"` string.
- When a `contract.action()` is called with an `Account` parameter, it converts automatically to string (no need to give `account.name`, `account` is enough)