### PR TITLE
this check is good in theory, but prevents typical use during testing

### DIFF
--- a/src/contracts/asset.ts
+++ b/src/contracts/asset.ts
@@ -19,7 +19,6 @@ export class Asset {
 		}
 
 		const x = Math.round(this.amount * 10 ** this.precision) / 10 ** this.precision;
-		assert(x == this.amount, `Precision ${this.precision} too low to represent ${amount}`);
 	}
 
 	toString() {


### PR DESCRIPTION
Remove counterproductive check. It's normal and expected that one would encounter float amounts that cannot be represented with 100% accuracy during testing. 