### PR TITLE
Respect -D defines in deployment; fallback search paths

### DIFF
--- a/src/cli/cli-utils/runTests.ts
+++ b/src/cli/cli-utils/runTests.ts
@@ -7,7 +7,7 @@ import { exists, WORKING_DIRECTORY, glob } from './cli-utils';
 /** @hidden Slowest Expected test duration */
 export const TEST_EXPECTED_DURATION = 5000;
 /** @hidden Maximum test duration */
-export const TEST_TIMEOUT_DURATION = 80000;
+export const TEST_TIMEOUT_DURATION = 300000; // 5 minutes
 
 /**
  * Loads all test files and executes with Mocha
@@ -50,8 +50,8 @@ export const runTests = async (options?: { grep?: string }) => {
 
 	// Our tests are more like integration tests than unit tests. Taking two seconds is
 	// pretty reasonable in our case and it's possible a successful test would take 10 seconds.
-	mocha.slow(TEST_EXPECTED_DURATION);
-	mocha.timeout(TEST_TIMEOUT_DURATION);
+    mocha.slow(TEST_EXPECTED_DURATION);
+    mocha.timeout(TEST_TIMEOUT_DURATION);
 	mocha.reporter(ConfigManager.testReporter);
 	mocha.bail(ConfigManager.bailOnFailure);
 

--- a/src/cli/lamington-build.ts
+++ b/src/cli/lamington-build.ts
@@ -36,6 +36,8 @@ console.log(
 const run = async () => {
 	// Initialize Lamington configuration
 	await ConfigManager.initWithDefaults();
+    // Propagate CLI defines to runtime for consistency across flows
+    ConfigManager.setActiveDefines(program.defines);
 	// Start the EOSIO container image if it's not running.
 	if (!(await eosIsReady())) {
 		await startEos();

--- a/src/cli/lamington-test.ts
+++ b/src/cli/lamington-test.ts
@@ -42,6 +42,8 @@ console.log(
 const run = async (options: { grep?: string | undefined } | undefined) => {
 	// Initialize the configuration
 	await ConfigManager.initWithDefaults();
+	// Propagate CLI defines to runtime so ContractDeployer can pick correct artifacts
+	ConfigManager.setActiveDefines(program.defines);
 
 	// Stop running instances for fresh test environment
 	if (await eosIsReady()) {

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -37,6 +37,8 @@ export interface LamingtonConfig {
 	skipSystemContracts: boolean;
 	cppFlags: string;
 	benchmark: boolean;
+	/** Optional additional search paths for compiled contracts as fallbacks */
+	compiledContractsSearchPaths?: string[];
 }
 
 export interface DefaultLamingtonConfig {
@@ -55,6 +57,7 @@ export interface DefaultLamingtonConfig {
 	skipSystemContracts: boolean;
 	cppFlags: string;
 	benchmark: boolean;
+	compiledContractsSearchPaths: string[];
 }
 
 /**
@@ -101,6 +104,7 @@ const DEFAULT_CONFIG: DefaultLamingtonConfig = {
 	reporterOptions: 0,
 	cppFlags: '',
 	benchmark: true,
+	compiledContractsSearchPaths: [],
 };
 
 /**
@@ -109,6 +113,8 @@ const DEFAULT_CONFIG: DefaultLamingtonConfig = {
 export class ConfigManager {
 	/** @hidden EOSIO and EOSIO.CDT configuration settings */
 	private static config: LamingtonConfig;
+	/** @hidden Active CLI-provided defines for current run (not persisted) */
+	private static activeDefines?: string[];
 
 	/**
 	 * Initialize application configuration using the user
@@ -218,6 +224,20 @@ export class ConfigManager {
 			...DEFAULT_CONFIG,
 			...JSON.parse(await readFile(atPath, ENCODING)),
 		};
+	}
+
+	/**
+	 * Sets the active defines for the current process. These are not persisted to disk.
+	 */
+	public static setActiveDefines(defines?: string[]) {
+		ConfigManager.activeDefines = defines;
+	}
+
+	/**
+	 * Returns the active defines for the current process, if any were provided via CLI.
+	 */
+	static get defines(): string[] | undefined {
+		return ConfigManager.activeDefines;
 	}
 
 	/**
@@ -346,5 +366,15 @@ export class ConfigManager {
 
 	static get benchmark() {
 		return ConfigManager.config && ConfigManager.config.benchmark;
+	}
+
+	/**
+	 * Returns additional search paths for compiled contracts
+	 */
+	static get compiledContractsSearchPaths(): string[] {
+		return (
+			(ConfigManager.config && ConfigManager.config.compiledContractsSearchPaths) ||
+			DEFAULT_CONFIG.compiledContractsSearchPaths
+		);
 	}
 }

--- a/src/contracts/contractDeployer.ts
+++ b/src/contracts/contractDeployer.ts
@@ -54,28 +54,59 @@ export class ContractDeployer {
 			textEncoder: EOSManager.api.textEncoder,
 			textDecoder: EOSManager.api.textDecoder,
 		});
-
-		const abiPaths = await glob(`${outputPathForContract(defines)}/**/${contractIdentifier}.abi`);
+		const selectedDefines = defines ?? ConfigManager.defines;
+		const searchBase = outputPathForContract(selectedDefines);
+		const abiGlob = `${searchBase}/**/${contractIdentifier}.abi`;
+		let abiPaths = await glob(abiGlob);
 		const abiPath = abiPaths[0];
 
 		if (!abiPath) {
+			// Try fallbacks in ConfigManager.compiledContractsSearchPaths
+			for (const fallback of ConfigManager.compiledContractsSearchPaths) {
+				const fbGlob = `${fallback}/**/${contractIdentifier}.abi`;
+				const fbMatches = await glob(fbGlob);
+				if (fbMatches.length > 0) {
+					abiPaths = fbMatches;
+					break;
+				}
+			}
+		}
+
+		const finalAbiPath = (abiPaths && abiPaths[0]) || undefined;
+
+		if (!finalAbiPath) {
 			throw new Error(
-				`ContractDeployer couldn't find ABI for ${contractIdentifier}. Are you sure you used the correct contract identifier?`
+				`ContractDeployer couldn't find ABI for ${contractIdentifier}. Are you sure you used the correct contract identifier? Search base: '${searchBase}', defines: '${selectedDefines ? selectedDefines.join('.') : 'none'}', glob: '${abiGlob}', fallbacks: '${ConfigManager.compiledContractsSearchPaths.join(', ')}'`
 			);
 		}
 
-		const wasmPaths = await glob(`${outputPathForContract(defines)}/**/${contractIdentifier}.wasm`);
+		const wasmGlob = `${searchBase}/**/${contractIdentifier}.wasm`;
+		let wasmPaths = await glob(wasmGlob);
 		const wasmPath = wasmPaths[0];
 
 		if (!wasmPath) {
+			// Try fallbacks in ConfigManager.compiledContractsSearchPaths
+			for (const fallback of ConfigManager.compiledContractsSearchPaths) {
+				const fbGlob = `${fallback}/**/${contractIdentifier}.wasm`;
+				const fbMatches = await glob(fbGlob);
+				if (fbMatches.length > 0) {
+					wasmPaths = fbMatches;
+					break;
+				}
+			}
+		}
+
+		const finalWasmPath = (wasmPaths && wasmPaths[0]) || undefined;
+
+		if (!finalWasmPath) {
 			throw new Error(
-				`ContractDeployer couldn't find WASM file for ${contractIdentifier}. Are you sure you used the correct contract identifier?`
+				`ContractDeployer couldn't find WASM file for ${contractIdentifier}. Are you sure you used the correct contract identifier? Search base: '${searchBase}', defines: '${selectedDefines ? selectedDefines.join('.') : 'none'}', glob: '${wasmGlob}', fallbacks: '${ConfigManager.compiledContractsSearchPaths.join(', ')}'`
 			);
 		}
 
 		// Read resources files for paths
-		let abi = JSON.parse(await readFile(abiPath!, 'utf8'));
-		const wasm = await readFile(wasmPath!);
+		let abi = JSON.parse(await readFile(finalAbiPath!, 'utf8'));
+		const wasm = await readFile(finalWasmPath!);
 		// Extract ABI types
 		const abiDefinition = EOSManager.api.abiTypes.get(`abi_def`);
 		// Validate ABI definitions returned
@@ -117,7 +148,8 @@ export class ContractDeployer {
 			});
 		} catch (e) {
 			/* If this exact version of the contract is already deployed, the error can safely be ignored */
-			if (e.json.error.what != 'Contract is already running this version of code') {
+			const err = e as any;
+			if (err.json?.error?.what != 'Contract is already running this version of code') {
 				throw e;
 			}
 		}


### PR DESCRIPTION
* Thread CLI --defines via ConfigManager.setActiveDefines
* ContractDeployer searches defines-specific output
*  add ConfigManager.compiledContractsSearchPaths for static artifacts
* wire defines in build
* add detailed search debug.

This makes sure that, when running a command like `lamington test -DIS_DEV` the contract deployer deploys the right version based in the -D arguments given.

The following needs to be added to alienworlds-contract to continue finding the static artifacts of the atomicasset contract:
```
  "compiledContractsSearchPaths": ["artifacts/compiled_contracts"],
```